### PR TITLE
Fix: import modules starting with @

### DIFF
--- a/src/handle-files.js
+++ b/src/handle-files.js
@@ -1106,7 +1106,7 @@ function getImportedFiles(aDataRaw, relativePath) {
             if (tsconfig) {
                 tsconfig = await handleData.removeComments(tsconfig)
                 tsconfig = JSON5.parse(tsconfig)    // Allow trailing commas
-                tsPaths = tsconfig.compilerOptions && tsconfig.compilerOptions.paths && typeof tsconfig.compilerOptions.paths === 'object' ? Object.entries(tsconfig.compilerOptions.paths) : null
+                tsPaths = tsconfig.compilerOptions && tsconfig.compilerOptions.paths && typeof tsconfig.compilerOptions.paths === 'object' ? Object.entries(tsconfig.compilerOptions.paths) : []
             }
 
             for (let index = 0; index < importeds.length; ++index) {


### PR DESCRIPTION
I'm using typescript so I use `import` statements. 

One of the modules I import starts with "@" and since I don't have `paths` in my tsconfig.json 
 `tsPaths.find(...` results in a `Uncaught TypeError: Cannot read property 'find' of null`.

This just fixes the default value.