### PR TITLE
handle invalid regex erros

### DIFF
--- a/src/handle-data.js
+++ b/src/handle-data.js
@@ -484,33 +484,37 @@ function addReferenceToMethods(data, patterns) {
 function getQueryIndirectly(elem, request, objParameters) {
     for (let idx = 0; idx < request.length; ++idx) {
         let req = request[idx];
-        if (req && req.split(new RegExp('\\;|\\{|\\(|\\[|\\"|\\\'|\\`|\\}|\\)|\\]|\\:|\\,|\\*|\\!|\\|')).length == 1 && elem && elem.split(new RegExp(' .*?\\s*\\t*=\\s*\\t*' + req + '\\.\\s*\\t*query(\\s|\\n|;|\\t)', 'gmi').length > 1)) {
-            let queryVars = [];
-            let aQuerys = elem.split(new RegExp('\\s*\\t*=\\s*\\t*' + req + '\\.\\s*\\t*query(\\s|\\n|;|\\t)', 'i'));
-            aQuerys = aQuerys.slice(0, -1);
+        try {
+            if (req && req.split(new RegExp('\\;|\\{|\\(|\\[|\\"|\\\'|\\`|\\}|\\)|\\]|\\:|\\,|\\*|\\!|\\|')).length == 1 && elem && elem.split(new RegExp(' .*?\\s*\\t*=\\s*\\t*' + req + '\\.\\s*\\t*query(\\s|\\n|;|\\t)', 'gmi').length > 1)) {
+                let queryVars = [];
+                let aQuerys = elem.split(new RegExp('\\s*\\t*=\\s*\\t*' + req + '\\.\\s*\\t*query(\\s|\\n|;|\\t)', 'i'));
+                aQuerys = aQuerys.slice(0, -1);
 
-            if (aQuerys.length > 0) {
-                // get variables name
-                for (let idx = 0; idx < aQuerys.length; idx++) {
-                    if (aQuerys[idx] && aQuerys[idx].replaceAll(' ', '') != '') {
-                        queryVars.push(aQuerys[idx].split(new RegExp('\\s*|\\t*')).slice(-1)[0]);
+                if (aQuerys.length > 0) {
+                    // get variables name
+                    for (let idx = 0; idx < aQuerys.length; idx++) {
+                        if (aQuerys[idx] && aQuerys[idx].replaceAll(' ', '') != '') {
+                            queryVars.push(aQuerys[idx].split(new RegExp('\\s*|\\t*')).slice(-1)[0]);
+                        }
+                    }
+                    if (queryVars.length > 0) {
+                        queryVars.forEach(query => {
+                            if (query && query.split(new RegExp('\\;|\\{|\\(|\\[|\\"|\\\'|\\`|\\}|\\)|\\]|\\:|\\,|\\*|\\!|\\|')).length == 1) {
+                                let varNames = elem.split(new RegExp(' ' + query + '\\.')).splice(1);
+                                varNames = varNames.map(v => (v = v.split(new RegExp('\\s|;|\\n|\\t'))[0]));
+                                varNames.forEach(name => {
+                                    objParameters[name] = {
+                                        name,
+                                        in: 'query'
+                                    };
+                                });
+                            }
+                        });
                     }
                 }
-                if (queryVars.length > 0) {
-                    queryVars.forEach(query => {
-                        if (query && query.split(new RegExp('\\;|\\{|\\(|\\[|\\"|\\\'|\\`|\\}|\\)|\\]|\\:|\\,|\\*|\\!|\\|')).length == 1) {
-                            let varNames = elem.split(new RegExp(' ' + query + '\\.')).splice(1);
-                            varNames = varNames.map(v => (v = v.split(new RegExp('\\s|;|\\n|\\t'))[0]));
-                            varNames.forEach(name => {
-                                objParameters[name] = {
-                                    name,
-                                    in: 'query'
-                                };
-                            });
-                        }
-                    });
-                }
             }
+        } catch (e) {
+            console.log("Minor Skip");
         }
     }
     return objParameters;

--- a/src/handle-files.js
+++ b/src/handle-files.js
@@ -523,9 +523,15 @@ function readEndpointFile(filePath, pathRoute = '', relativePath, receivedRouteM
                                                 regexParams += `\\([\\w|\\s]*\\,?[\\w|\\s]*\\,?[\\w|\\s]*[\\s|\\,]+${funcParams[idx]}[\\s|\\,]+[\\w|\\s]*\\,?[\\w|\\s]*\\,?[\\w|\\s]*\\)|`;
                                             }
                                             regexParams = regexParams.slice(0, -1);
-                                            let refFunc = funcNotRefFormated.split(new RegExp(regexParams));
+                                            let refFunc;
+                                            try {
+                                                const regex = new RegExp(regexParams);
+                                                refFunc = funcNotRefFormated.split(regex);
+                                            } catch (e) {
+                                              console.log("Minor Skip");
+                                            }
 
-                                            if (refFunc.length > 1) {
+                                            if (refFunc && refFunc.length > 1) {
                                                 if (tsFunction) {
                                                     refFunc = refFunc.slice(0, -1);
                                                 } else {


### PR DESCRIPTION
Very often, while generating swagger output for our repo we are seeing errors like this:
(node:132292) UnhandledPromiseRejectionWarning: SyntaxError: Invalid regular expression: / .*?\s*\t*=\s*\t*+type\.\s*\t*query(\s|\n|;|\t)/: Nothing to repeat
    at new RegExp (<anonymous>)
    at Object.getQueryIndirectly (D:\projects\sunstone\placement_apis\node_modules\swagger-autogen\src\handle-data.js:487:140)
    at D:\projects\sunstone\placement_apis\node_modules\swagger-autogen\src\handle-files.js:1056:64

It turns out, the regex may not form correctly in a lot of edge cases. I've added try catch blocks for such exceptions. Let's discuss if you have any queries or need some of my routes that are causing these issues, as this PR is just a stopgap and does not address the actual issue.
