### PR TITLE
adding support for ref in parameters

### DIFF
--- a/src/handle-files.js
+++ b/src/handle-files.js
@@ -1248,10 +1248,22 @@ function readEndpointFile(filePath, pathRoute = '', relativePath, receivedRouteM
                                 }
                             });
 
-                            // Remove duplicates
+
                             if (objEndpoint[path][method] && objEndpoint[path][method].parameters && objEndpoint[path][method].parameters.length > 0) {
-                                objEndpoint[path][method].parameters = objEndpoint[path][method].parameters.filter((e, pIdx, a) => {
-                                    let idxFound = a.findIndex(i => i.in && e.in && i.name && e.name && i.in === e.in && i.name === e.name);
+                                let currentParameters = objEndpoint[path][method].parameters;
+                                let ref = '$ref';
+
+                                // Remove all other properties from ref parameters
+                                currentParameters = currentParameters.map(x => {
+                                    if (Object.prototype.hasOwnProperty.call(x, ref)) {
+                                        return {[ref]: x[ref]}
+                                    }
+                                    return x;
+                                })
+
+                                // Remove duplicates
+                                objEndpoint[path][method].parameters = currentParameters.filter((e, pIdx, a) => {
+                                    let idxFound = a.findIndex(i => (i.in && e.in && i.name && e.name && i.in === e.in && i.name === e.name) || (i[ref] && e[ref] && i[ref] == e[ref]));
                                     if (idxFound == -1 || idxFound === pIdx) return true;
                                 });
                             }

--- a/src/swagger-tags.js
+++ b/src/swagger-tags.js
@@ -331,8 +331,19 @@ async function getParametersTag(data, objParameters, reference) {
         let swaggerParameters = data.split(new RegExp(`${statics.SWAGGER_TAG}.parameters`));
         swaggerParameters.shift();
         for (let idx = 0; idx < swaggerParameters.length; ++idx) {
-            let parameter = await utils.stack0SymbolRecognizer(swaggerParameters[idx], '{', '}');
             let name = swaggerParameters[idx].split(new RegExp('\\[|\\]'))[1].replaceAll("'", '');
+            if (getOpenAPI() && name === '$ref') {
+                let rest = swaggerParameters[idx].split('=')[1];
+                let parameter = rest.substring(rest.indexOf("'") + 1, rest.lastIndexOf("'"));
+                if (parameter) {
+                    objParameters[name] = { [name]: parameter };
+                } else {
+                    console.error(`[swagger-autogen]: '${statics.SWAGGER_TAG}.parameters' out of structure in '${reference.filePath}' ... ${reference.predefPattern}.${reference.method}('${reference.path}', ...)`);
+                    return origObjParameters;
+                }
+                continue;
+            }
+            let parameter = await utils.stack0SymbolRecognizer(swaggerParameters[idx], '{', '}');
 
             try {
                 objParameters[name] = {

--- a/src/swagger-tags.js
+++ b/src/swagger-tags.js
@@ -332,25 +332,18 @@ async function getParametersTag(data, objParameters, reference) {
         swaggerParameters.shift();
         for (let idx = 0; idx < swaggerParameters.length; ++idx) {
             let name = swaggerParameters[idx].split(new RegExp('\\[|\\]'))[1].replaceAll("'", '');
-            if (getOpenAPI() && name === '$ref') {
-                let rest = swaggerParameters[idx].split('=')[1];
-                let parameter = rest.substring(rest.indexOf("'") + 1, rest.lastIndexOf("'"));
-                if (parameter) {
-                    objParameters[name] = { [name]: parameter };
-                } else {
-                    console.error(`[swagger-autogen]: '${statics.SWAGGER_TAG}.parameters' out of structure in '${reference.filePath}' ... ${reference.predefPattern}.${reference.method}('${reference.path}', ...)`);
-                    return origObjParameters;
-                }
-                continue;
-            }
             let parameter = await utils.stack0SymbolRecognizer(swaggerParameters[idx], '{', '}');
 
             try {
+                let parameterObj = eval(`(${'{' + parameter + '}'})`);
                 objParameters[name] = {
                     name,
                     ...objParameters[name],
-                    ...eval(`(${'{' + parameter + '}'})`)
+                    ...parameterObj
                 };
+                if (Object.prototype.hasOwnProperty.call(parameterObj, '$ref')) {
+                    continue;
+                }
             } catch (err) {
                 console.error('[swagger-autogen]: Syntax error: ' + parameter);
                 console.error(`[swagger-autogen]: '${statics.SWAGGER_TAG}.parameters' out of structure in '${reference.filePath}' ... ${reference.predefPattern}.${reference.method}('${reference.path}', ...)`);


### PR DESCRIPTION
This is to provide support for the use case mentioned here: https://github.com/davibaltar/swagger-autogen/issues/124

It allows further use of the components object as defined here: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#componentsObject

This allows you to add something like this to your comment block: 
```#swagger.parameters['reuseableparam'] = { '$ref': '#/components/parameters/reuseableparam'}```

And something like this to your components definition:
```
components: {
    parameters: {
        reuseableparam: {
            name: "reuseableparam",
            in: "query",
            required: true,
            description: "A Reuseable parameter",
            schema: {
                type: "string",
                example: "example"
            }
        }
    }
}
```

I am not sure at all as to what the preferred design would be to define a reference in the comment block

Some potential alternative designs?
```
#swagger.parameters['$ref'] = ['#/components/parameters/reuseableparam', '#/components/parameters/reuseableparam2']`

#swagger.parameters['#/components/parameters/reuseableparam2']`

```