### PR TITLE
Add multiple servers section to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,40 @@ swaggerAutogen({openapi: '3.0.0'})(outputFile, endpointsFiles, doc).then(async (
   await import('./index.js'); // Your project's root file
 });
 ```
+### Multiple servers
+_To use this feature, enable OpenAPI [[click here](#openapi-3x)]._
+to use multiple servers for the same swagger documentation, add them to `servers` array.
+```js
+const doc = {
+  info: {
+    version: '',      // by default: '1.0.0'
+    title: '',        // by default: 'REST API'
+    description: '',  // by default: ''
+  },
+  servers: [
+    {
+      url: "http://localhost:3000/",
+      description: "local server"
+    },
+    {
+      url: "http://localhost:5000/",
+      description: "the other server"
+    }
+  ],
+  consumes: [],  // by default: ['application/json']
+  produces: [],  // by default: ['application/json']
+  tags: [        // by default: empty Array
+    {
+      name: '',         // Tag name
+      description: '',  // Tag description
+    },
+    // { ... }
+  ],
+  securityDefinitions: {},  // by default: empty object
+  definitions: {},          // by default: empty object (Swagger 2.0)
+  components: {}            // by default: empty object (OpenAPI 3.x)
+};
+```
 
 ### Request Body
 _To use this feature, enable OpenAPI [[click here](#openapi-3x)]._


### PR DESCRIPTION
I was trying to use it, and it just works :smile:  so I decided to add it to the documentation.

example:
https://s3.us-west-1.wasabisys.com/idbwmedia.com/images/api/openapi_serversurl.png
![alt text](https://s3.us-west-1.wasabisys.com/idbwmedia.com/images/api/openapi_serversurl.png)